### PR TITLE
Name collision issue in Remote Redux DevTools is fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,5 @@ See [remote-redux-devtools](https://github.com/zalmoxisus/remote-redux-devtools)
 
 [React Native Upgrading](http://facebook.github.io/react-native/docs/upgrading.html)
 
-## Troubleshooting
-
-#### Naming collision detected
-
-```
-Failed to build DependencyGraph:
-Naming collision detected:
-/Users/dbrowne/Sites/react-native-counter-ios-android/node_modules/remote-redux-devtools/node_modules/react/node_modules/fbjs/lib/warning.js collides with /Users/dbrowne/Sites/react-native-counter-ios-android/node_modules/react-native/node_modules/fbjs/lib/warning.js
-
-Error:
-Naming collision detected:
-/Users/dbrowne/Sites/react-native-counter-ios-android/node_modules/remote-redux-devtools/node_modules/react/node_modules/fbjs/lib/warning.js collides with /Users/dbrowne/Sites/react-native-counter-ios-android/node_modules/react-native/node_modules/fbjs/lib/warning.js
-```
-
-see https://github.com/chentsulin/react-native-counter-ios-android/issues/12#issuecomment-186542678.
-
 ## License
 MIT © [C. T. Lin](https://github.com/chentsulin)


### PR DESCRIPTION
As we're using [`redux-devtools-instrument`](https://github.com/zalmoxisus/redux-devtools-instrument) and there's no dependency to React anymore
